### PR TITLE
chore: Update package name to tr31 for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ The library provides detailed error messages through two custom error types:
 Unwraps a TR-31 formatted key block to retrieve the original key. 
 
 ```bash
-Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkUnwrap_D_32_WithSetup$ github.com/moov-io/tr31/pkg/encryption
+Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkUnwrap_D_32_WithSetup$ github.com/moov-io/tr31/pkg/tr31
 
 goos: darwin
 goarch: arm64
-pkg: github.com/moov-io/tr31/pkg/encryption
+pkg: github.com/moov-io/tr31/pkg/tr31
 cpu: Apple M1 Pro
 BenchmarkUnwrap_D_32_WithSetup-10    	  301116	      3619 ns/op	    8608 B/op	      64 allocs/op
 ```

--- a/pkg/server/wrapper.go
+++ b/pkg/server/wrapper.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 
-	"github.com/moov-io/tr31/pkg/encryption"
+	"github.com/moov-io/tr31/pkg/tr31"
 )
 
 type UnifiedParams struct {
@@ -19,7 +19,7 @@ type WrapperCall func(params UnifiedParams) (string, error)
 func InitialKey(params UnifiedParams) (string, error) {
 	planData := []byte(params.VaultAddr + params.VaultToken)
 	kbpk := bytes.Repeat([]byte("E"), 24)
-	encData, err := encryption.GenerateCBCMAC(kbpk, planData, 1, 8, encryption.DES)
+	encData, err := tr31.GenerateCBCMAC(kbpk, planData, 1, 8, tr31.DES)
 	if err != nil {
 		return "", err
 	}
@@ -29,7 +29,7 @@ func InitialKey(params UnifiedParams) (string, error) {
 func TransactionKey(params UnifiedParams) (string, error) {
 	planData := []byte(params.VaultAddr + params.VaultToken)
 	kbpk := bytes.Repeat([]byte("F"), 24)
-	encData, err := encryption.GenerateCBCMAC(kbpk, planData, 1, 8, encryption.DES)
+	encData, err := tr31.GenerateCBCMAC(kbpk, planData, 1, 8, tr31.DES)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/tr31/aes.go
+++ b/pkg/tr31/aes.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"crypto/aes"

--- a/pkg/tr31/aes_test.go
+++ b/pkg/tr31/aes_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"crypto/aes"

--- a/pkg/tr31/des.go
+++ b/pkg/tr31/des.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"crypto/cipher"

--- a/pkg/tr31/des_test.go
+++ b/pkg/tr31/des_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"bytes"

--- a/pkg/tr31/helpers_test.go
+++ b/pkg/tr31/helpers_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"crypto/rand"

--- a/pkg/tr31/kbpk.go
+++ b/pkg/tr31/kbpk.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"crypto/rand"

--- a/pkg/tr31/kbpk_test.go
+++ b/pkg/tr31/kbpk_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"testing"

--- a/pkg/tr31/mac.go
+++ b/pkg/tr31/mac.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"encoding/binary"

--- a/pkg/tr31/mac_test.go
+++ b/pkg/tr31/mac_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"bytes"

--- a/pkg/tr31/tools.go
+++ b/pkg/tr31/tools.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"crypto/subtle"

--- a/pkg/tr31/tools_test.go
+++ b/pkg/tr31/tools_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"bytes"

--- a/pkg/tr31/tr31.go
+++ b/pkg/tr31/tr31.go
@@ -1,7 +1,7 @@
-// Package encryption implements the TR-31 (ANSI X9.143) key block standard for secure cryptographic key exchange.
+// Package tr31 implements the TR-31 (ANSI X9.143) key block standard for secure cryptographic key exchange.
 // TR-31 provides a method for secure exchange of cryptographic keys by wrapping them in a secure key block
 // that includes metadata about the key's usage, algorithm, and other attributes.
-package encryption
+package tr31
 
 import (
 	"crypto/rand"

--- a/pkg/tr31/tr31_benchmark_test.go
+++ b/pkg/tr31/tr31_benchmark_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"encoding/hex"

--- a/pkg/tr31/tr31_test.go
+++ b/pkg/tr31/tr31_test.go
@@ -1,4 +1,4 @@
-package encryption
+package tr31
 
 import (
 	"bytes"


### PR DESCRIPTION
- Renamed package encryption to package tr31 for consistency across the codebase.

Fixes: https://github.com/moov-io/tr31/issues/9 