### PR TITLE
make hex uppercase as per the specification

### DIFF
--- a/pkg/tr31/tr31.go
+++ b/pkg/tr31/tr31.go
@@ -1145,7 +1145,7 @@ func (kb *KeyBlock) DWrap(header string, key []byte, extraPad int) (string, erro
 	}
 
 	// Return the concatenated result
-	return header + hex.EncodeToString(encKey) + hex.EncodeToString(mac), nil
+	return header + strings.ToUpper(hex.EncodeToString(encKey)+hex.EncodeToString(mac)), nil
 }
 func (kb *KeyBlock) dDerive() ([]byte, []byte, error) {
 	// Key Derivation data


### PR DESCRIPTION
in the specification the content is defined as hex-ascii which is only 'A-Z' 0-9

![image](https://github.com/user-attachments/assets/0c4c37c6-3247-4f76-8e46-76dabfb984f2)
